### PR TITLE
Guice support for cache annotations

### DIFF
--- a/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/ClassHeader.txt
+++ b/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/ClassHeader.txt
@@ -1,0 +1,16 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */

--- a/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/checkstyle.xml
+++ b/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/checkstyle.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+    <property name="severity" value="error"/>
+
+    <module name="Translation">
+        <property name="severity" value="error"/>
+    </module>
+
+    <module name="JavadocPackage">
+        <property name="allowLegacy" value="true"/>
+    </module>
+
+    <!-- Header -->
+    <module name="Header">
+        <property name="headerFile" value="${checkstyle.header.file}"/>
+    </module>
+
+    <module name="FileLength">
+        <property name="max" value="1400"/>
+    </module>
+
+    <!-- Duplicate Code -->
+    <module name="StrictDuplicateCode">
+        <property name="min" value="30"/>
+    </module>
+    
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+        <property name="severity" value="warning"/>
+    </module>
+
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous -->
+    <module name="RegexpSingleline">
+        <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+        <property name="format" value="System\.out\.println"/>
+    </module>
+    <!-- Make sure commons logging is not used -->
+    <module name="RegexpSingleline">
+        <property name="format" value="import org\.apache\.commons\.logging\.Log;"/>
+    </module>
+    <!-- Make sure we are using safe element.get methods everywhere -->
+    <module name="RegexpSingleline">
+        <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+        <property name="format" value="[^entry]\\.getKey\\(\\)"/>
+    </module>
+    <module name="RegexpSingleline">
+        <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+        <property name="format" value="[^entry]\\.getValue\\(\\)"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!--<property name="cacheFile" value="checkstyle.cache}"/>-->
+        
+        <!--Java 5 checks-->
+        <module name="MissingDeprecated">
+            <property name="severity" value="warning"/>
+        </module>
+
+        <!-- javadoc -->
+        <module name="JavadocType"/>
+        <module name="JavadocMethod">
+            <property name="scope" value="package"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowUndeclaredRTE" value="true"/>
+        </module>
+        <module name="JavadocVariable">
+            <property name="scope" value="package"/>
+        </module>
+        <module name="JavadocStyle">
+            <property name="scope" value="public"/>
+            <property name="checkFirstSentence" value="false"/>
+        </module>
+
+        <!-- Naming Conventions -->
+        <module name="ConstantName"/>
+        <module name="MethodName"/>
+        <module name="StaticVariableName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+        </module>
+        <module name="ParameterName"/>
+        <module name="TypeName"/>
+
+
+        <!-- Imports -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Size Violations -->
+        <module name="LineLength">
+            <property name="max" value="150"/>
+            <property name="ignorePattern" value="^ *\* *"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="200"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="60"/>
+            <property name="tokens" value="CTOR_DEF"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="8"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="12"/>
+            <property name="tokens" value="CTOR_DEF"/>
+        </module>
+        <module name="AnonInnerLength">
+            <property name="max" value="25"/>
+        </module>
+        <module name="ExecutableStatementCount">
+            <property name="max" value="20"/>
+            <property name="tokens" value="CTOR_DEF, INSTANCE_INIT, STATIC_INIT"/>
+        </module>
+
+        <!-- Whitespace -->
+        <module name="EmptyForInitializerPad"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter">
+            <property name="allowLineBreaks" value="false"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="allowLineBreaks" value="false"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA, SEMI"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="tokens"
+                      value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="tokens"
+                      value="ASSIGN, DIV_ASSIGN, PLUS_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN, SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN"/>
+            <property name="option" value="eol"/>
+        </module>
+
+        <!-- Modifiers -->
+        <module name="ModifierOrder">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="RedundantModifier">
+            <property name="severity" value="warning"/>
+        </module>
+
+        <!-- Blocks -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+            <property name="tokens" value="LITERAL_CATCH"/>
+        </module>
+        <module name="EmptyBlock">
+            <property name="tokens"
+                      value="LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_IF, LITERAL_FOR, LITERAL_TRY, LITERAL_WHILE, STATIC_INIT"/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="same"/>
+        </module>
+        <module name="LeftCurly"/>
+        <module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true"/>
+        </module>
+
+        <!-- Coding Problems -->
+        <module name="ArrayTrailingComma"/>
+        <module name="CovariantEquals"/>
+        <module name="DeclarationOrder"/>
+        <module name="ParameterAssignment"/>
+        <module name="ExplicitInitialization"/>
+        <module name="DefaultComesLast"/>
+        <module name="FallThrough"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="DoubleCheckedLocking"/>
+        <module name="EmptyStatement"/>
+        <module name="HiddenField">
+            <property name="tokens" value="VARIABLE_DEF"/>
+        </module>
+        <module name="IllegalInstantiation">
+            <property name="classes" value="java.lang.Boolean"/>
+        </module>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="NUM_INT,NUM_LONG"/>
+            <property name="format" value="^0[^lx]"/>
+            <property name="ignoreCase" value="true"/>
+        </module>
+        <module name="IllegalType">
+            <property name="ignoredMethodNames" value="getInstance"/>
+            <property name="tokens" value="PARAMETER_DEF, METHOD_DEF"/>
+        </module>
+        <module name="InnerAssignment"/>
+        <module name="JUnitTestCase"/>
+        <module name="ReturnCount">
+            <property name="max" value="5"/>
+        </module>
+        <module name="NestedIfDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="NestedTryDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="PackageDeclaration"/>
+        <module name="RedundantThrows">
+            <property name="severity" value="warning"/>
+            <property name="allowUnchecked" value="true"/>
+        </module>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality"/>
+        <module name="SuperClone"/>
+        <module name="SuperFinalize"/>
+        <!--<module name="MagicNumber"/>-->
+        <module name="EqualsHashCode"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MissingSwitchDefault"/>
+
+        <!-- Class Design -->
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="InterfaceIsType"/>
+        <module name="MutableException"/>
+        <module name="ThrowsCount">
+            <property name="max" value="3"/>
+        </module>
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
+
+        <!-- Metrics -->
+        <module name="BooleanExpressionComplexity">
+            <property name="max" value="4"/>
+        </module>
+        <module name="ClassDataAbstractionCoupling">
+            <property name="max" value="15"/>
+        </module>
+        <module name="ClassFanOutComplexity">
+            <property name="max" value="40"/>
+        </module>
+        <module name="CyclomaticComplexity">
+            <property name="severity" value="error"/>
+            <property name="max" value="12"/>
+        </module>
+        <module name="NPathComplexity">
+            <property name="max" value="50"/>
+        </module>
+
+        <module name="ArrayTypeStyle"/>
+        <!--<module name="TodoComment"/>-->
+        <module name="TrailingComment"/>
+        <module name="UpperEll"/>
+    </module>
+</module>

--- a/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/suppressions.xml
+++ b/cache-annotations-ri/cache-annotations-ri-guice/checkstyle/suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <!-- Suppress duplicate checking of copyright notice -->
+    <suppress checks="StrictDuplicateCode" files=".java" lines="1-53"/>
+
+    <suppress checks="NPathComplexity" files="RICache.java"/>
+    <suppress checks="CyclomaticComplexity" files="RICacheConfiguration.java"/>
+    <suppress checks="NPathComplexity" files="RICacheConfiguration.java"/>
+
+    <suppress checks="NPathComplexity" files="AbstractCacheLookupUtil.java"/>
+    <suppress checks="CyclomaticComplexity" files="AbstractCacheLookupUtil.java"/>
+
+</suppressions>

--- a/cache-annotations-ri/cache-annotations-ri-guice/pom.xml
+++ b/cache-annotations-ri/cache-annotations-ri-guice/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>javax.cache.implementation</groupId>
+        <artifactId>cache-annotations-ri</artifactId>
+        <version>0.5-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>cache-annotations-ri-guice</artifactId>
+    <packaging>jar</packaging>
+
+    <name>JSR107 Annotations RI Guice Support</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<guice.version>3.0</guice.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cache-annotations-ri-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+    
+</project>

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheLookupUtil.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheLookupUtil.java
@@ -1,0 +1,97 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import com.google.inject.Injector;
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.CacheKeyGenerator;
+import javax.cache.annotation.CacheResolverFactory;
+import javax.cache.annotation.impl.AbstractCacheLookupUtil;
+import javax.cache.annotation.impl.InternalCacheInvocationContext;
+import javax.cache.annotation.impl.InternalCacheKeyInvocationContext;
+import javax.cache.annotation.impl.StaticCacheInvocationContext;
+import javax.cache.annotation.impl.StaticCacheKeyInvocationContext;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+@Singleton
+public class CacheLookupUtil extends AbstractCacheLookupUtil<MethodInvocation> {
+
+    private final Injector injector;
+    private final CacheKeyGenerator defaultCacheKeyGenerator;
+    private final CacheResolverFactory defaultCacheResolverFactory;
+
+    /**
+     * @param injector Guice injector
+     * @param defaultCacheKeyGenerator the default CacheKeyGenerator
+     * @param defaultCacheResolverFactory the default CacheResolverFactory
+     */
+    @Inject
+    public CacheLookupUtil(Injector injector, CacheKeyGenerator defaultCacheKeyGenerator,
+                           CacheResolverFactory defaultCacheResolverFactory) {
+        this.injector = injector;
+        this.defaultCacheKeyGenerator = defaultCacheKeyGenerator;
+        this.defaultCacheResolverFactory = defaultCacheResolverFactory;
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @Override
+    protected InternalCacheKeyInvocationContext<? extends Annotation> createCacheKeyInvocationContextImpl(
+            StaticCacheKeyInvocationContext<? extends Annotation> staticCacheKeyInvocationContext, MethodInvocation invocation) {
+        return new GuiceInternalCacheKeyInvocationContext(staticCacheKeyInvocationContext, invocation);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @Override
+    protected InternalCacheInvocationContext<? extends Annotation> createCacheInvocationContextImpl(
+            StaticCacheInvocationContext<? extends Annotation> staticCacheInvocationContext, MethodInvocation invocation) {
+        return new GuiceInternalCacheInvocationContext(staticCacheInvocationContext, invocation);
+    }
+
+    @Override
+    protected Class<?> getTargetClass(MethodInvocation invocation) {
+        return invocation.getThis().getClass();
+    }
+
+    @Override
+    protected Method getMethod(MethodInvocation invocation) {
+        return invocation.getMethod();
+    }
+
+    @Override
+    protected <T> T getObjectByType(Class<T> type) {
+        return this.injector.getInstance(type);
+    }
+
+    @Override
+    protected CacheKeyGenerator getDefaultCacheKeyGenerator() {
+        return this.defaultCacheKeyGenerator;
+    }
+
+    @Override
+    protected CacheResolverFactory getDefaultCacheResolverFactory() {
+        return this.defaultCacheResolverFactory;
+    }
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheMethodInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheMethodInterceptor.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInterceptor;
+
+import javax.cache.annotation.impl.InterceptorType;
+
+/**
+ * Common subclass for all jcache interceptors
+ *
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public interface CacheMethodInterceptor extends MethodInterceptor {
+    /**
+     * @return The type of intereceptor
+     */
+    InterceptorType getInterceptorType();
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CachePutInterceptor.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractCachePutInterceptor;
+import javax.cache.annotation.impl.CacheContextSource;
+import javax.cache.annotation.impl.InterceptorType;
+import javax.inject.Inject;
+
+/**
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public class CachePutInterceptor extends AbstractCachePutInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+    private CacheContextSource<MethodInvocation> cacheContextSource;
+
+    /**
+     * @param cacheContextSource the CacheContextSource to use
+     */
+    @Inject
+    public void setCacheContextSource(CacheContextSource<MethodInvocation> cacheContextSource) {
+        this.cacheContextSource = cacheContextSource;
+    }
+
+    @Override
+    public InterceptorType getInterceptorType() {
+        return InterceptorType.CACHE_PUT;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        return this.cachePut(cacheContextSource, invocation);
+    }
+
+    @Override
+    protected Object proceed(MethodInvocation invocation) throws Throwable {
+        return invocation.proceed();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheRemoveAllInterceptor.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractCacheRemoveAllInterceptor;
+import javax.cache.annotation.impl.CacheContextSource;
+import javax.cache.annotation.impl.InterceptorType;
+import javax.inject.Inject;
+
+/**
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<MethodInvocation>
+    implements CacheMethodInterceptor {
+
+    private CacheContextSource<MethodInvocation> cacheContextSource;
+
+    /**
+     * @param cacheContextSource the CacheContextSource to use
+     */
+    @Inject
+    public void setCacheContextSource(CacheContextSource<MethodInvocation> cacheContextSource) {
+        this.cacheContextSource = cacheContextSource;
+    }
+
+    @Override
+    public InterceptorType getInterceptorType() {
+        return InterceptorType.CACHE_REMOVE_ALL;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        return this.cacheRemoveAll(cacheContextSource, invocation);
+    }
+
+    @Override
+    protected Object proceed(MethodInvocation invocation) throws Throwable {
+        return invocation.proceed();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheRemoveEntryInterceptor.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractCacheRemoveEntryInterceptor;
+import javax.cache.annotation.impl.CacheContextSource;
+import javax.cache.annotation.impl.InterceptorType;
+import javax.inject.Inject;
+
+/**
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<MethodInvocation>
+    implements CacheMethodInterceptor {
+
+    private CacheContextSource<MethodInvocation> cacheContextSource;
+
+    /**
+     * @param cacheContextSource the CacheContextSource to use
+     */
+    @Inject
+    public void setCacheContextSource(CacheContextSource<MethodInvocation> cacheContextSource) {
+        this.cacheContextSource = cacheContextSource;
+    }
+
+    @Override
+    public InterceptorType getInterceptorType() {
+        return InterceptorType.CACHE_REMOVE_ENTRY;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        return this.cacheRemoveEntry(cacheContextSource, invocation);
+    }
+
+    @Override
+    protected Object proceed(MethodInvocation invocation) throws Throwable {
+        return invocation.proceed();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheResultInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/CacheResultInterceptor.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractCacheResultInterceptor;
+import javax.cache.annotation.impl.CacheContextSource;
+import javax.cache.annotation.impl.InterceptorType;
+import javax.inject.Inject;
+
+/**
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public class CacheResultInterceptor extends AbstractCacheResultInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+    private CacheContextSource<MethodInvocation> cacheContextSource;
+
+    /**
+     * @param cacheContextSource the CacheContextSource to use
+     */
+    @Inject
+    public void setCacheContextSource(CacheContextSource<MethodInvocation> cacheContextSource) {
+        this.cacheContextSource = cacheContextSource;
+    }
+
+    @Override
+    public InterceptorType getInterceptorType() {
+        return InterceptorType.CACHE_RESULT;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        return this.cacheResult(cacheContextSource, invocation);
+    }
+
+    @Override
+    protected Object proceed(MethodInvocation invocation) throws Throwable {
+        return invocation.proceed();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/GuiceInternalCacheInvocationContext.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/GuiceInternalCacheInvocationContext.java
@@ -1,0 +1,65 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractInternalCacheInvocationContext;
+import javax.cache.annotation.impl.StaticCacheInvocationContext;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * Guice specific cache invocation context using {@link MethodInvocation}
+ *
+ * @author Michael Stachel
+ * @version $Revision$
+ * @param <A> The type of annotation this context information is for. One of {@link javax.cache.annotation.CacheResult},
+ * {@link javax.cache.annotation.CachePut}, {@link javax.cache.annotation.CacheRemoveEntry}, or
+ * {@link javax.cache.annotation.CacheRemoveAll}.
+ */
+public class GuiceInternalCacheInvocationContext<A extends Annotation> extends
+        AbstractInternalCacheInvocationContext<MethodInvocation, A> {
+
+    /**
+     * Create new cache key invocation context for the static context and invocation
+     *
+     * @param staticCacheInvocationContext Static information about the invoked method
+     * @param invocation The AOP Alliance invocation context
+     */
+    public GuiceInternalCacheInvocationContext(StaticCacheInvocationContext<A> staticCacheInvocationContext,
+            MethodInvocation invocation) {
+        super(staticCacheInvocationContext, invocation);
+    }
+
+    @Override
+    protected Object[] getParameters(MethodInvocation invocation) {
+        return invocation.getArguments();
+    }
+
+    @Override
+    protected Method getMethod(MethodInvocation invocation) {
+        return invocation.getMethod();
+    }
+
+    @Override
+    protected Object getTarget(MethodInvocation invocation) {
+        return invocation.getThis();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/GuiceInternalCacheKeyInvocationContext.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/GuiceInternalCacheKeyInvocationContext.java
@@ -1,0 +1,65 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.impl.AbstractInternalCacheKeyInvocationContext;
+import javax.cache.annotation.impl.StaticCacheKeyInvocationContext;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * Guice specific cache key invocation context using {@link MethodInvocation}
+ *
+ * @author Michael Stachel
+ * @version $Revision$
+ * @param <A> The type of annotation this context information is for. One of {@link javax.cache.annotation.CacheResult},
+ * {@link javax.cache.annotation.CachePut}, {@link javax.cache.annotation.CacheRemoveEntry}, or
+ * {@link javax.cache.annotation.CacheRemoveAll}.
+ */
+public class GuiceInternalCacheKeyInvocationContext<A extends Annotation> extends
+        AbstractInternalCacheKeyInvocationContext<MethodInvocation, A> {
+
+    /**
+     * Create new cache key invocation context for the static context and invocation
+     *
+     * @param staticCacheKeyInvocationContext Static information about the invoked method
+     * @param invocation The AOP Alliance invocation context
+     */
+    public GuiceInternalCacheKeyInvocationContext(StaticCacheKeyInvocationContext<A> staticCacheKeyInvocationContext,
+            MethodInvocation invocation) {
+        super(staticCacheKeyInvocationContext, invocation);
+    }
+
+    @Override
+    protected Object[] getParameters(MethodInvocation invocation) {
+        return invocation.getArguments();
+    }
+
+    @Override
+    protected Method getMethod(MethodInvocation invocation) {
+        return invocation.getMethod();
+    }
+
+    @Override
+    protected Object getTarget(MethodInvocation invocation) {
+        return invocation.getThis();
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/module/CacheAnnotationsModule.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/module/CacheAnnotationsModule.java
@@ -1,0 +1,78 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice.module;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matchers;
+import org.aopalliance.intercept.MethodInvocation;
+
+import javax.cache.annotation.CacheKeyGenerator;
+import javax.cache.annotation.CachePut;
+import javax.cache.annotation.CacheRemoveAll;
+import javax.cache.annotation.CacheRemoveEntry;
+import javax.cache.annotation.CacheResolverFactory;
+import javax.cache.annotation.CacheResult;
+import javax.cache.annotation.impl.CacheContextSource;
+import javax.cache.annotation.impl.DefaultCacheKeyGenerator;
+import javax.cache.annotation.impl.DefaultCacheResolverFactory;
+import javax.cache.annotation.impl.guice.CacheLookupUtil;
+import javax.cache.annotation.impl.guice.CachePutInterceptor;
+import javax.cache.annotation.impl.guice.CacheRemoveAllInterceptor;
+import javax.cache.annotation.impl.guice.CacheRemoveEntryInterceptor;
+import javax.cache.annotation.impl.guice.CacheResultInterceptor;
+
+/**
+ * Standard cache module for binding all cache interceptors to their respective annotations. This module needs to be part of the
+ * Guice injector instantiation to activate intercepting of the cache annotations.
+ * Every interceptor is bound twice due to the fact that the annotations defining the joinpoints have retention type
+ * Method and Type.
+ *
+ * @author Michael Stachel
+ * @version $Revision$
+ */
+public class CacheAnnotationsModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(CacheKeyGenerator.class).to(DefaultCacheKeyGenerator.class);
+        bind(CacheResolverFactory.class).to(DefaultCacheResolverFactory.class);
+        bind(new TypeLiteral<CacheContextSource<MethodInvocation>>() { }).to(CacheLookupUtil.class);
+
+        CachePutInterceptor cachePutInterceptor = new CachePutInterceptor();
+        requestInjection(cachePutInterceptor);
+        bindInterceptor(Matchers.annotatedWith(CachePut.class), Matchers.any(), cachePutInterceptor);
+        bindInterceptor(Matchers.any(), Matchers.annotatedWith(CachePut.class), cachePutInterceptor);
+
+        CacheResultInterceptor cacheResultInterceptor = new CacheResultInterceptor();
+        requestInjection(cacheResultInterceptor);
+        bindInterceptor(Matchers.annotatedWith(CacheResult.class), Matchers.any(), cacheResultInterceptor);
+        bindInterceptor(Matchers.any(), Matchers.annotatedWith(CacheResult.class), cacheResultInterceptor);
+
+        CacheRemoveEntryInterceptor cacheRemoveEntryInterceptor = new CacheRemoveEntryInterceptor();
+        requestInjection(cacheRemoveEntryInterceptor);
+        bindInterceptor(Matchers.annotatedWith(CacheRemoveEntry.class), Matchers.any(), cacheRemoveEntryInterceptor);
+        bindInterceptor(Matchers.any(), Matchers.annotatedWith(CacheRemoveEntry.class), cacheRemoveEntryInterceptor);
+
+        CacheRemoveAllInterceptor cacheRemoveAllInterceptor = new CacheRemoveAllInterceptor();
+        requestInjection(cacheRemoveAllInterceptor);
+        bindInterceptor(Matchers.annotatedWith(CacheRemoveAll.class), Matchers.any(), cacheRemoveAllInterceptor);
+        bindInterceptor(Matchers.any(), Matchers.annotatedWith(CacheRemoveAll.class), cacheRemoveAllInterceptor);
+    }
+
+}

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/module/package-info.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/module/package-info.java
@@ -1,0 +1,18 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice.module;

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/package-info.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/javax/cache/annotation/impl/guice/package-info.java
@@ -1,0 +1,18 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package javax.cache.annotation.impl.guice;

--- a/cache-annotations-ri/pom.xml
+++ b/cache-annotations-ri/pom.xml
@@ -15,5 +15,6 @@
         <module>cache-annotations-ri-cdi</module>
         <module>cache-annotations-ri-common</module>
         <module>cache-annotations-ri-spring</module>
+        <module>cache-annotations-ri-guice</module>
     </modules>
 </project>


### PR DESCRIPTION
Added an implementation on top of the cache-annotations-ri-common for using the cache annotations in Google Guice. The implementation is similiar to the Spring one because both are using AopAlliance API for interceptors under the hood. What differs is the process of wiring. 
