### PR TITLE
Interceptor names in beans.xml do not match actual class names

### DIFF
--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/resources/META-INF/beans.xml
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/resources/META-INF/beans.xml
@@ -3,9 +3,9 @@
 http://java.sun.com/xml/ns/javaee
 http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
     <interceptors>
-        <class>javax.cache.annotation.impl.cdi.CacheResultInterceptor</class>
-        <class>javax.cache.annotation.impl.cdi.CachePutInterceptor</class>
-        <class>javax.cache.annotation.impl.cdi.CacheRemoveEntryInterceptor</class>
-        <class>javax.cache.annotation.impl.cdi.CacheRemoveAllInterceptor</class>
+        <class>org.jsr107.ri.annotations.cdi.CacheResultInterceptor</class>
+        <class>org.jsr107.ri.annotations.cdi.CachePutInterceptor</class>
+        <class>org.jsr107.ri.annotations.cdi.CacheRemoveEntryInterceptor</class>
+        <class>org.jsr107.ri.annotations.cdi.CacheRemoveAllInterceptor</class>
     </interceptors>
 </beans>


### PR DESCRIPTION
Updated interceptor names in beans.xml from javax.cache... to org.jsr107...
