### PR TITLE
 CacheManager.getCacheNames() yields IllegalStateException, if closed.

### DIFF
--- a/cache-ri-impl/src/main/java/org/jsr107/ri/RICacheManager.java
+++ b/cache-ri-impl/src/main/java/org/jsr107/ri/RICacheManager.java
@@ -259,6 +259,9 @@ public class RICacheManager implements CacheManager {
    */
   @Override
   public Iterable<String> getCacheNames() {
+    if (isClosed()) {
+      throw new IllegalStateException();
+    }
     synchronized (caches) {
       HashSet<String> set = new HashSet<String>();
       for (Cache<?, ?> cache : caches.values()) {


### PR DESCRIPTION
Fix for: https://github.com/jsr107/RI/issues/48
Fixes TCK challenge: https://github.com/jsr107/jsr107tck/issues/87
