### PR TITLE
Fixes #46 - Interceptors implement correct Java EE method signature using generics

### DIFF
--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CachePutInterceptor.java
@@ -35,7 +35,7 @@ import javax.interceptor.InvocationContext;
  */
 @CachePut
 @Interceptor
-public class CachePutInterceptor extends AbstractCachePutInterceptor<InvocationContext> {
+public class CachePutInterceptor extends AbstractCachePutInterceptor<InvocationContext, Exception> {
 
   @Inject
   private CacheLookupUtil lookup;
@@ -44,10 +44,10 @@ public class CachePutInterceptor extends AbstractCachePutInterceptor<InvocationC
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cachePut(InvocationContext invocationContext) throws Throwable {
+  public Object cachePut(InvocationContext invocationContext) throws Exception {
     return this.cachePut(this.lookup, invocationContext);
   }
 

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveAllInterceptor.java
@@ -35,17 +35,17 @@ import javax.interceptor.InvocationContext;
  */
 @CacheRemoveAll
 @Interceptor
-public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<InvocationContext> {
+public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<InvocationContext, Exception> {
   @Inject
   private CacheLookupUtil lookup;
 
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheRemoveAll(InvocationContext invocationContext) throws Throwable {
+  public Object cacheRemoveAll(InvocationContext invocationContext) throws Exception {
     return this.cacheRemoveAll(this.lookup, invocationContext);
   }
 

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveEntryInterceptor.java
@@ -35,7 +35,7 @@ import javax.interceptor.InvocationContext;
  */
 @CacheRemove
 @Interceptor
-public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<InvocationContext> {
+public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<InvocationContext, Exception> {
 
   @Inject
   private CacheLookupUtil lookup;
@@ -44,10 +44,10 @@ public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterce
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheRemoveEntry(InvocationContext invocationContext) throws Throwable {
+  public Object cacheRemoveEntry(InvocationContext invocationContext) throws Exception {
     return this.cacheRemoveEntry(this.lookup, invocationContext);
   }
 

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResultInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResultInterceptor.java
@@ -35,7 +35,7 @@ import javax.interceptor.InvocationContext;
  */
 @CacheResult
 @Interceptor
-public class CacheResultInterceptor extends AbstractCacheResultInterceptor<InvocationContext> {
+public class CacheResultInterceptor extends AbstractCacheResultInterceptor<InvocationContext, Exception> {
 
   @Inject
   private CacheLookupUtil lookup;
@@ -43,10 +43,10 @@ public class CacheResultInterceptor extends AbstractCacheResultInterceptor<Invoc
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheResult(InvocationContext invocationContext) throws Throwable {
+  public Object cacheResult(InvocationContext invocationContext) throws Exception {
     return this.cacheResult(this.lookup, invocationContext);
   }
 

--- a/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheInterceptor.java
@@ -21,17 +21,18 @@ package org.jsr107.ri.annotations;
  * Base class for cache related interceptors
  *
  * @param <I> The intercepted method invocation
+ * @param <E> The exception type that is thrown
  * @author Eric Dalquist
  * @since 1.0
  */
-public abstract class AbstractCacheInterceptor<I> {
+public abstract class AbstractCacheInterceptor<I, E extends Throwable> {
   /**
    * Proceed with the invocation
    *
    * @param invocation The intercepted invocation
    * @return The value returned by the invocation
-   * @throws Throwable The exception thrown by the invocation, if any
+   * @throws E The exception thrown by the invocation, if any
    */
-  protected abstract Object proceed(I invocation) throws Throwable;
+  protected abstract Object proceed(I invocation) throws E;
 
 }

--- a/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCachePutInterceptor.java
@@ -23,6 +23,7 @@ import javax.cache.annotation.CacheKeyGenerator;
 import javax.cache.annotation.CachePut;
 import javax.cache.annotation.CacheResolver;
 import javax.cache.annotation.GeneratedCacheKey;
+
 import java.lang.annotation.Annotation;
 
 
@@ -30,11 +31,12 @@ import java.lang.annotation.Annotation;
  * Interceptor for {@link CachePut}
  *
  * @param <I> The intercepted method invocation
+ * @param <E> The exception type that is thrown
  * @author Rick Hightower
  * @author Eric Dalquist
  * @since 1.0
  */
-public abstract class AbstractCachePutInterceptor<I> extends AbstractKeyedCacheInterceptor<I, CachePutMethodDetails> {
+public abstract class AbstractCachePutInterceptor<I, E extends Throwable> extends AbstractKeyedCacheInterceptor<I, E, CachePutMethodDetails> {
 
   /**
    * Handles the {@link Cache#put(Object, Object)} as specified for the {@link CachePut} annotation
@@ -42,9 +44,9 @@ public abstract class AbstractCachePutInterceptor<I> extends AbstractKeyedCacheI
    * @param cacheContextSource The intercepted invocation
    * @param invocation         The intercepted invocation
    * @return The result from {@link #proceed(Object)}
-   * @throws Throwable if {@link #proceed(Object)} threw
+   * @throws E if {@link #proceed(Object)} threw
    */
-  public Object cachePut(CacheContextSource<I> cacheContextSource, I invocation) throws Throwable {
+  public Object cachePut(CacheContextSource<I> cacheContextSource, I invocation) throws E {
     final InternalCacheKeyInvocationContext<? extends Annotation> cacheKeyInvocationContext =
         cacheContextSource.getCacheKeyInvocationContext(invocation);
     final CachePutMethodDetails methodDetails = this.getStaticCacheKeyInvocationContext(cacheKeyInvocationContext, InterceptorType.CACHE_PUT);

--- a/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheRemoveAllInterceptor.java
@@ -20,6 +20,7 @@ package org.jsr107.ri.annotations;
 import javax.cache.Cache;
 import javax.cache.annotation.CacheRemoveAll;
 import javax.cache.annotation.CacheResolver;
+
 import java.lang.annotation.Annotation;
 
 
@@ -27,20 +28,21 @@ import java.lang.annotation.Annotation;
  * Interceptor for {@link CacheRemoveAll}
  *
  * @param <I> The intercepted method invocation
+ * @param <E> The exception type that is thrown
  * @author Rick Hightower
  * @author Eric Dalquist
  * @since 1.0
  */
-public abstract class AbstractCacheRemoveAllInterceptor<I> extends AbstractCacheInterceptor<I> {
+public abstract class AbstractCacheRemoveAllInterceptor<I, E extends Throwable> extends AbstractCacheInterceptor<I, E> {
   /**
    * Handles the {@link Cache#removeAll()} as specified for the {@link CacheRemoveAll} annotation
    *
    * @param cacheContextSource The intercepted invocation
    * @param invocation         The intercepted invocation
    * @return The result from {@link #proceed(Object)}
-   * @throws Throwable if {@link #proceed(Object)} threw
+   * @throws E if {@link #proceed(Object)} threw
    */
-  public final Object cacheRemoveAll(CacheContextSource<I> cacheContextSource, I invocation) throws Throwable {
+  public final Object cacheRemoveAll(CacheContextSource<I> cacheContextSource, I invocation) throws E {
     final InternalCacheInvocationContext<? extends Annotation> cacheInvocationContext = cacheContextSource.getCacheInvocationContext(invocation);
 
     final StaticCacheInvocationContext<CacheRemoveAll> methodDetails =

--- a/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractCacheRemoveEntryInterceptor.java
@@ -22,6 +22,7 @@ import javax.cache.annotation.CacheKeyGenerator;
 import javax.cache.annotation.CacheRemove;
 import javax.cache.annotation.CacheResolver;
 import javax.cache.annotation.GeneratedCacheKey;
+
 import java.lang.annotation.Annotation;
 
 
@@ -29,11 +30,13 @@ import java.lang.annotation.Annotation;
  * Interceptor for {@link javax.cache.annotation.CacheRemove}
  *
  * @param <I> The intercepted method invocation
+ * @param <E> The exception type that is thrown
  * @author Rick Hightower
  * @author Eric Dalquist
  * @since 1.0
  */
-public abstract class AbstractCacheRemoveEntryInterceptor<I> extends AbstractKeyedCacheInterceptor<I, CacheRemoveEntryMethodDetails> {
+public abstract class AbstractCacheRemoveEntryInterceptor<I, E extends Throwable> 
+  extends AbstractKeyedCacheInterceptor<I, E, CacheRemoveEntryMethodDetails> {
 
   /**
    * Handles the {@link Cache#remove(Object)} as specified for the {@link javax.cache.annotation.CacheRemove} annotation
@@ -41,9 +44,9 @@ public abstract class AbstractCacheRemoveEntryInterceptor<I> extends AbstractKey
    * @param cacheContextSource The intercepted invocation
    * @param invocation         The intercepted invocation
    * @return The result from {@link #proceed(Object)}
-   * @throws Throwable if {@link #proceed(Object)} threw
+   * @throws E if {@link #proceed(Object)} threw
    */
-  public final Object cacheRemoveEntry(CacheContextSource<I> cacheContextSource, I invocation) throws Throwable {
+  public final Object cacheRemoveEntry(CacheContextSource<I> cacheContextSource, I invocation) throws E {
     final InternalCacheKeyInvocationContext<? extends Annotation> cacheKeyInvocationContext =
         cacheContextSource.getCacheKeyInvocationContext(invocation);
     final CacheRemoveEntryMethodDetails methodDetails =

--- a/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractKeyedCacheInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-common/src/main/java/org/jsr107/ri/annotations/AbstractKeyedCacheInterceptor.java
@@ -22,11 +22,14 @@ import java.lang.annotation.Annotation;
  * Base class for all interceptor implementations, contains utility methods
  *
  * @param <I> The intercepted method invocation
+ * @param <E> The exception type that is thrown
  * @param <T> The type of static invocation context data expected
+ * 
  * @author Eric Dalquist
  * @since 1.0
  */
-public abstract class AbstractKeyedCacheInterceptor<I, T extends StaticCacheKeyInvocationContext<?>> extends AbstractCacheInterceptor<I> {
+public abstract class AbstractKeyedCacheInterceptor<I, E extends Throwable, T extends StaticCacheKeyInvocationContext<?>> 
+  extends AbstractCacheInterceptor<I, E> {
 
   /**
    * Get, check the {@link InterceptorType} and cast the {@link CacheMethodDetailsImpl} for the invocation.

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CachePutInterceptor.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
  * @author Michael Stachel
  * @version $Revision$
  */
-public class CachePutInterceptor extends AbstractCachePutInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CachePutInterceptor extends AbstractCachePutInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheRemoveAllInterceptor.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
  * @author Michael Stachel
  * @version $Revision$
  */
-public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<MethodInvocation>
+public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<MethodInvocation, Throwable>
     implements CacheMethodInterceptor {
 
   private CacheContextSource<MethodInvocation> cacheContextSource;

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheRemoveEntryInterceptor.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
  * @author Michael Stachel
  * @version $Revision$
  */
-public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<MethodInvocation>
+public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<MethodInvocation, Throwable>
     implements CacheMethodInterceptor {
 
   private CacheContextSource<MethodInvocation> cacheContextSource;

--- a/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheResultInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-guice/src/main/java/org/jsr107/ri/annotations/guice/CacheResultInterceptor.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
  * @author Michael Stachel
  * @version $Revision$
  */
-public class CacheResultInterceptor extends AbstractCacheResultInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CacheResultInterceptor extends AbstractCacheResultInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CachePutInterceptor.java
@@ -26,7 +26,7 @@ import org.jsr107.ri.annotations.InterceptorType;
  * @author Eric Dalquist
  * @version $Revision$
  */
-public class CachePutInterceptor extends AbstractCachePutInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CachePutInterceptor extends AbstractCachePutInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private final CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheRemoveAllInterceptor.java
@@ -26,7 +26,7 @@ import org.jsr107.ri.annotations.InterceptorType;
  * @author Eric Dalquist
  * @version $Revision$
  */
-public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private final CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheRemoveEntryInterceptor.java
@@ -26,7 +26,7 @@ import org.jsr107.ri.annotations.InterceptorType;
  * @author Eric Dalquist
  * @version $Revision$
  */
-public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private final CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheResultInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/CacheResultInterceptor.java
@@ -26,7 +26,7 @@ import org.jsr107.ri.annotations.InterceptorType;
  * @author Eric Dalquist
  * @version $Revision$
  */
-public class CacheResultInterceptor extends AbstractCacheResultInterceptor<MethodInvocation> implements CacheMethodInterceptor {
+public class CacheResultInterceptor extends AbstractCacheResultInterceptor<MethodInvocation, Throwable> implements CacheMethodInterceptor {
   private final CacheContextSource<MethodInvocation> cacheContextSource;
 
   /**

--- a/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/config/AnnotationDrivenJCacheBeanDefinitionParser.java
+++ b/cache-annotations-ri/cache-annotations-ri-spring/src/main/java/org/jsr107/ri/annotations/spring/config/AnnotationDrivenJCacheBeanDefinitionParser.java
@@ -154,7 +154,7 @@ public class AnnotationDrivenJCacheBeanDefinitionParser implements BeanDefinitio
    *
    * @return Reference to the {@link org.aopalliance.intercept.MethodInterceptor}. Should never be null.
    */
-  protected RuntimeBeanReference setupInterceptor(Class<? extends AbstractCacheInterceptor<?>> interceptorClass,
+  protected RuntimeBeanReference setupInterceptor(Class<? extends AbstractCacheInterceptor<?, Throwable>> interceptorClass,
                                                   ParserContext parserContext, Object elementSource,
                                                   RuntimeBeanReference cacheOperationSourceRuntimeReference) {
 
@@ -175,7 +175,7 @@ public class AnnotationDrivenJCacheBeanDefinitionParser implements BeanDefinitio
    * Create {@link org.springframework.aop.PointcutAdvisor} that puts the
    * {@link org.springframework.aop.Pointcut} and {@link AbstractCacheInterceptor} together.
    */
-  protected void setupPointcutAdvisor(Class<? extends AbstractCacheInterceptor<?>> interceptorClass,
+  protected void setupPointcutAdvisor(Class<? extends AbstractCacheInterceptor<?, Throwable>> interceptorClass,
                                       Element element, ParserContext parserContext,
                                       Object elementSource, RuntimeBeanReference cacheOperationSourceReference) {
 


### PR DESCRIPTION
This fix uses a generics a bit unconventionally (throws E).
