### PR TITLE
Fixes #46 - Interceptors implement correct Java EE method signature

### DIFF
--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CachePutInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CachePutInterceptor.java
@@ -44,11 +44,19 @@ public class CachePutInterceptor extends AbstractCachePutInterceptor<InvocationC
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cachePut(InvocationContext invocationContext) throws Throwable {
-    return this.cachePut(this.lookup, invocationContext);
+  public Object cachePut(InvocationContext invocationContext) throws Exception {
+    try {
+        return this.cachePut(this.lookup, invocationContext);
+    } catch (Throwable e) {
+        if (e instanceof Exception) {
+            throw (Exception) e;
+        } else {
+            throw new Exception(e);
+        }
+    }
   }
 
   /* (non-Javadoc)

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveAllInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveAllInterceptor.java
@@ -42,11 +42,19 @@ public class CacheRemoveAllInterceptor extends AbstractCacheRemoveAllInterceptor
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheRemoveAll(InvocationContext invocationContext) throws Throwable {
-    return this.cacheRemoveAll(this.lookup, invocationContext);
+  public Object cacheRemoveAll(InvocationContext invocationContext) throws Exception {
+    try {
+        return this.cacheRemoveAll(this.lookup, invocationContext);
+    } catch (Throwable e) {
+        if (e instanceof Exception) {
+            throw (Exception) e;
+        } else {
+            throw new Exception(e);
+        }
+    }
   }
 
   /* (non-Javadoc)

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveEntryInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheRemoveEntryInterceptor.java
@@ -44,11 +44,19 @@ public class CacheRemoveEntryInterceptor extends AbstractCacheRemoveEntryInterce
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheRemoveEntry(InvocationContext invocationContext) throws Throwable {
-    return this.cacheRemoveEntry(this.lookup, invocationContext);
+  public Object cacheRemoveEntry(InvocationContext invocationContext) throws Exception {
+    try {
+        return this.cacheRemoveEntry(this.lookup, invocationContext);
+    } catch (Throwable e) {
+        if (e instanceof Exception) {
+            throw (Exception) e;
+        } else {
+            throw new Exception(e);
+        }
+    }
   }
 
   /* (non-Javadoc)

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResultInterceptor.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResultInterceptor.java
@@ -43,11 +43,19 @@ public class CacheResultInterceptor extends AbstractCacheResultInterceptor<Invoc
   /**
    * @param invocationContext The intercepted invocation
    * @return The result from {@link InvocationContext#proceed()}
-   * @throws Throwable likely {@link InvocationContext#proceed()} threw an exception
+   * @throws Exception likely {@link InvocationContext#proceed()} threw an exception
    */
   @AroundInvoke
-  public Object cacheResult(InvocationContext invocationContext) throws Throwable {
-    return this.cacheResult(this.lookup, invocationContext);
+  public Object cacheResult(InvocationContext invocationContext) throws Exception {
+    try {
+        return this.cacheResult(this.lookup, invocationContext);
+    } catch (Throwable e) {
+        if (e instanceof Exception) {
+            throw (Exception) e;
+        } else {
+            throw new Exception(e);
+        }
+    }
   }
 
   /* (non-Javadoc)


### PR DESCRIPTION
Here is an alternative pull request that catches Throwable and changes it to Exception as pr EE spec.
