### PR TITLE
Copy all properties from CachingProvider.getCacheManager(URL, ClassLoader, Properties)

### DIFF
--- a/cache-ri-impl/src/main/java/org/jsr107/ri/RICacheManager.java
+++ b/cache-ri-impl/src/main/java/org/jsr107/ri/RICacheManager.java
@@ -77,15 +77,12 @@ public class RICacheManager implements CacheManager {
     }
     this.classLoaderReference = new WeakReference<ClassLoader>(classLoader);
 
-    //
     this.properties = new Properties();
     if (properties != null) {
-      for (Object key : properties.keySet()) {
-        this.properties.put(key, properties.get(key));
+      for (String key : properties.stringPropertyNames()) {
+        this.properties.setProperty(key, properties.getProperty(key));
       }
     }
-
-    //this.properties = properties == null ? new Properties() : new Properties(properties);
 
     isClosed = false;
   }


### PR DESCRIPTION
When a `CacheManager` is created with `CachingProvider.getCacheManager(URL, ClassLoader, Properties), then all properties, both defaults & those explicitly set on given argument `Properties`, must be preserved, so they are available from `CacheManager.getProperties()`.

Fixes #55