### PR TITLE
Do not throw UnsupportedOperationException from CacheEntryEvent.getOldValue

### DIFF
--- a/cache-ri-impl/src/main/java/org/jsr107/ri/event/RICacheEntryEvent.java
+++ b/cache-ri-impl/src/main/java/org/jsr107/ri/event/RICacheEntryEvent.java
@@ -89,11 +89,11 @@ public class RICacheEntryEvent<K, V> extends CacheEntryEvent<K, V> {
    * {@inheritDoc}
    */
   @Override
-  public V getOldValue() throws UnsupportedOperationException {
+  public V getOldValue() {
     if (isOldValueAvailable()) {
       return oldValue;
     } else {
-      throw new UnsupportedOperationException("Old value is not available for key");
+      return null;
     }
   }
 


### PR DESCRIPTION
When old value is not available `null` should be returned.

See https://github.com/jsr107/jsr107spec/issues/391